### PR TITLE
automatic package discovery

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ classifiers =
 [options]
 zip_safe = False
 include_package_data = True
-packages = find:
 install_requires = 
 	edgetest
 	pip-tools<=7.3.0,>=6.0.0


### PR DESCRIPTION
# edgetest-pip-tools version 2023.8.0

## Description

Enables automatic package discovery, prevents inclusion of tests directory in install ([see related edgetest pr](https://github.com/capitalone/edgetest/pull/73))